### PR TITLE
Rewrite

### DIFF
--- a/vimrc-mode.el
+++ b/vimrc-mode.el
@@ -3,7 +3,8 @@
 ;; Copyright (C) 2013 Andrew Pennebaker
 ;; Copyright (C) 2011 Alpha Tan
 
-;; Authors: Andrew Pennebaker
+;; Authors: Mark Oteiza
+;;          Andrew Pennebaker
 ;;          Alpha Tan <alphatan.zh@gmail.com>
 ;; URL: https://github.com/mcandre/vimrc-mode
 ;; Version: 0.3.1
@@ -601,7 +602,7 @@
                              "folddoopen" "foldd"
                              "foldopen" "foldo"
                              "for" "endfo" "endfor"
-                             "fu" "function"
+                             "fu" "fun" "function"
                              "goto" "go"
                              "grep" "gr"
                              "grepadd" "grepa"
@@ -859,7 +860,6 @@
                              "topleft" "to"
                              "tprevious" "tp"
                              "trewind" "tr"
-                             "try"
                              "try" "endt" "endtry"
                              "tselect" "ts"
                              "tunmenu" "tu"


### PR DESCRIPTION
changes:
- change all the regexes from being explicitly written out to use `regexp-opt`, attempting to have each long keyword with its associated short keywords/aliases (whatever they are) on the same line
- add a mode customization group
- introduce some mode-specific faces so that they can be configured, add them under their own customization group
- change some of the existing regexen to be more accurate (largely according to vim's own syntax file).  in doing so, remove some superfluous commenting
- simplify the comment highlighting, because the comment/string business is pretty broken
- derive from prog-mode if possible

new:
- function navigation (C-M-a and C-M-e)
- simple imenu integration
