### PR TITLE
Correct syntax-table mistake breaking up coffee-mode

### DIFF
--- a/vimrc-mode.el
+++ b/vimrc-mode.el
@@ -1217,7 +1217,6 @@ With argument, repeat ARG times."
   (re-search-forward (concat  "^[ \t]*\\(endf\\(?:unction\\)?\\)\\b")
                       nil 'move (or arg 1)))
 
-;;;###autoload
 (defvar vimrc-mode-syntax-table
   (let ((table (make-syntax-table)))
     (modify-syntax-entry ?\" "." table)


### PR DESCRIPTION
See https://github.com/defunkt/coffee-mode/issues/252 for more details

I took the liberty of removing the autoload as I don't see what it helps with, the syntax table will be loaded when vimrc-mode loads anyway.
