### PR TITLE
Make the # character a symbol constituent

### DIFF
--- a/vimrc-mode.el
+++ b/vimrc-mode.el
@@ -1241,6 +1241,7 @@ With argument, repeat ARG times."
 (defvar vimrc-mode-syntax-table
   (let ((table (make-syntax-table)))
     (modify-syntax-entry ?\" "." table)
+    (modify-syntax-entry ?# "_" table)
     table))
 
 ;;;###autoload (add-to-list 'auto-mode-alist '("\\.vim\\'" . vimrc-mode))


### PR DESCRIPTION
Hi there,

Just a minor change I think is useful.

Vim functions defined in the `autoload/` directory have `#` characters as part of their name.
This matches how vim behaves (`set iskeyword?` includes the `#` character for `ft=vim` buffers).