### PR TITLE
Add syntax entries for comments and strings

### DIFF
--- a/vimrc-mode.el
+++ b/vimrc-mode.el
@@ -1240,8 +1240,10 @@ With argument, repeat ARG times."
 
 (defvar vimrc-mode-syntax-table
   (let ((table (make-syntax-table)))
-    (modify-syntax-entry ?\" "." table)
-    (modify-syntax-entry ?# "_" table)
+    (modify-syntax-entry ?'  "\"" table)
+    (modify-syntax-entry ?\" "<"  table)
+    (modify-syntax-entry ?\n ">"  table)
+    (modify-syntax-entry ?#  "_"  table)
     table))
 
 ;;;###autoload (add-to-list 'auto-mode-alist '("\\.vim\\'" . vimrc-mode))


### PR DESCRIPTION
* `vimrc-mode.el` (`vimrc-mode-syntax-table`): Set syntax for single-quoted strings and for comments.