### PR TITLE
Some small additions

### DIFF
--- a/vimrc-mode.el
+++ b/vimrc-mode.el
@@ -588,6 +588,7 @@
                              "dsplit" "dsp"
                              "earlier"
                              "echoerr" "echoe"
+                             "echohl" "echoh"
                              "echomsg" "echom"
                              "echon"
                              "edit" "e"

--- a/vimrc-mode.el
+++ b/vimrc-mode.el
@@ -92,6 +92,10 @@
      ("\\(\\([a-zA-Z]*:\\)?[a-zA-Z]*\\)("
        (1 font-lock-function-name-face nil t)) ;; Function-name end;
 
+     ;; Function special arguments
+     ("\\(fun\\(?:ction\\)?\\)!?.+?\\(\\(range\\|abort\\|dict\\|closure\\)\\([ \t]+\\(range\\|abort\\|dict\\|closure\\)\\)*\\)[ \t]*$"
+       (2 '(face vimrc-command)))
+
      ;; Variables
      ("\\<[bwglsav]:[a-zA-Z_][a-zA-Z0-9#_]*\\>"
        (0 font-lock-variable-name-face))


### PR DESCRIPTION
These are some additions that I would like to add, which I ran into while working on some Vimscript code.

The "function special arguments" part is a bit unwieldy but it basically matches any combination of whitespace-separated `range`, `abort`, `dict`, or `closure` after a `function ...()` definition. If desired, see `:h :func-range` `:h :func-abort` `:h :func-dict` `:h :func-closure` for more details.

`echohl` is self explanatory.